### PR TITLE
List all available rake tasks, not just those with doc strings

### DIFF
--- a/projectile-rails.el
+++ b/projectile-rails.el
@@ -404,9 +404,9 @@ Returns a hash table with keys being short names and values being relative paths
      (projectile-rails-with-root
       (shell-command-to-string
        (projectile-rails-with-preloader
-	:spring "spring rake -T"
-	:zeus "zeus rake -T"
-	:vanilla "bundle exec rake -T"))))))
+	:spring "spring rake -T -A"
+	:zeus "zeus rake -T -A"
+	:vanilla "bundle exec rake -T -A"))))))
 
 (defun projectile-rails-rake (task)
   (interactive


### PR DESCRIPTION
If a task is 'uncommented' `rake -T` won't list it.  `rake -T -A` on the other hand returns a list of all tasks, even those that are without documentation.  The latter result is what we want.  An example of a task that was missing from the list is `db:test:prepare`
