### PR TITLE
Make `projectile-rails-current-resource-name` migrations aware

### DIFF
--- a/features/extracting-region.feature
+++ b/features/extracting-region.feature
@@ -1,5 +1,5 @@
 Feature: Extracting region
-  
+
 Scenario: Extracting a region to a partial
   Given file "app/views/admin/users/index.html.erb" exists
   And I open the app file "app/views/admin/users/index.html.erb"

--- a/features/font-locking.feature
+++ b/features/font-locking.feature
@@ -2,7 +2,7 @@ Feature: Font locking rails specific keywords
   In order to read the rails application source code
   As a user
   I want to see rails keywords highlighted
-  
+
 Scenario: Font locking models keywords
   Given file "app/models/user.rb" exists
   And I open the app file "app/models/user.rb"

--- a/features/generate.feature
+++ b/features/generate.feature
@@ -2,7 +2,7 @@ Feature: Using rails generate command
   In order to generate projects's files
   As a user
   I want to be able to run rails generate command from Emacs
-  
+
 Scenario: Runnning generate rspec:install
   Given I open the app file "app/models/user.rb"
   And I turn on projectile-mode
@@ -39,5 +39,3 @@ Scenario: Using buttons
   When I place the cursor between "conflict  spe" and "c"
   And I press "RET"
   Then I am in file "spec/spec_helper.rb"
-
-

--- a/features/navigation/finding-logs.feature
+++ b/features/navigation/finding-logs.feature
@@ -2,7 +2,7 @@ Feature: Opening logs file
   In order to read log files
   As a user
   I want to be able to watch log files
-  
+
 Scenario: Opening development log
   Given I open the app file "app/models/user.rb"
   And file "log/development.log" exists

--- a/features/navigation/finding-resources.feature
+++ b/features/navigation/finding-resources.feature
@@ -41,7 +41,7 @@ Feature: Finding resources
     And file "features/user.feature" exists
     When I run command "projectile-rails-find-feature" selecting "user"
     Then I am in file "features/user.feature"
-    
+
   Scenario: Finding migration
     And file "db/migrate/12345678901234_create_users.rb" exists
     When I run command "projectile-rails-find-migration" selecting "12345678901234_create_users"
@@ -56,4 +56,3 @@ Feature: Finding resources
     And file "app/assets/stylesheets/foo.js" exists
     When I run command "projectile-rails-find-stylesheet" selecting "foo"
     Then I am in file "app/assets/stylesheets/foo.js"
-

--- a/features/navigation/going-from-controller-to-template-at-point.feature
+++ b/features/navigation/going-from-controller-to-template-at-point.feature
@@ -2,7 +2,7 @@ Feature: Going from a controller to a template at point
   In order to do find fast templates and partials at point
   As a user
   I want to be able to run projectile-rails command and jump to the template or partial at point
-  
+
   Scenario: Going from: format.html { render 'users/index' }
     Given file "app/views/admin/users/new.html.haml" exists
     And I open the app file "app/controllers/admin/users_controller.rb"

--- a/features/navigation/going-from-template-to-tomplate-at-point.feature
+++ b/features/navigation/going-from-template-to-tomplate-at-point.feature
@@ -2,8 +2,8 @@ Feature: Going from a template to a template at point
   In order to do find fast templates and partials at point
   As a user
   I want to be able to run projectile-rails command and jump to the template or partial at point
-  
-  
+
+
 Scenario: Going from: render 'index'
   And file "app/views/users/index.html.erb" exists
   And I open the app file "app/views/users/new.html.erb"

--- a/features/navigation/going-to-constant-at-point.feature
+++ b/features/navigation/going-to-constant-at-point.feature
@@ -74,7 +74,7 @@ Feature: Going to constant at point
     And I place the cursor between "Admin::Log" and "ging"
     When I run "projectile-rails-goto-file-at-point"
     Then I am in file "lib/admin/logging.rb"
-    
+
   Scenario: Going to ruby constant which is a controller
     And file "app/controllers/admin/users_controller.rb" exists
     And I clear the buffer and insert:
@@ -84,7 +84,7 @@ Feature: Going to constant at point
     And I place the cursor between "Admin::Use" and "rs"
     When I run "projectile-rails-goto-file-at-point"
     Then I am in file "app/controllers/admin/users_controller.rb"
-    
+
   Scenario: Going to ruby constant which is defined in app/jobs
     And file "app/jobs/admin/foo_bar_job.rb" exists
     And I clear the buffer and insert:
@@ -94,7 +94,7 @@ Feature: Going to constant at point
     And I place the cursor between "Foo" and "Bar"
     When I run "projectile-rails-goto-file-at-point"
     Then I am in file "app/jobs/admin/foo_bar_job.rb"
-    
+
   Scenario: Not going to non-existant model
     And I clear the buffer and insert:
     """

--- a/features/navigation/going-to-current-resource-file.feature
+++ b/features/navigation/going-to-current-resource-file.feature
@@ -2,7 +2,7 @@ Feature: Finding current resource
   In order to go to current resources
   As a user
   I want to be able to find resources connected with the file I'm currently visiting
-  
+
   Scenario: Finding current model
     Given file "app/models/user.rb" exists
     And I open the app file "app/controllers/users_controller.rb"
@@ -17,7 +17,7 @@ Feature: Finding current resource
     And I turn on projectile-mode
     When I run command "projectile-rails-find-current-controller" selecting "users_controller.rb"
     Then I am in file "app/controllers/users_controller.rb"
-    
+
   Scenario: Finding current view
     Given file "app/views/users/index.html.erb" exists
     And file "app/views/users/new.html.erb" exists
@@ -25,14 +25,14 @@ Feature: Finding current resource
     And I turn on projectile-mode
     When I run command "projectile-rails-find-current-view" selecting "users/new.html.erb"
     Then I am in file "app/views/users/new.html.erb"
-    
+
   Scenario: Finding current helper
     Given file "app/helpers/users_helper.rb" exists
     And I open the app file "app/models/user.rb"
     And I turn on projectile-mode
     When I run "projectile-rails-find-current-helper"
     Then I am in file "app/helpers/users_helper.rb"
-      
+
   Scenario: Finding current spec
     Given file "spec/controllers/users_controller_spec.rb" exists
     And file "spec/controllers/admin/users_controller_spec.rb" exists

--- a/features/navigation/going-to-file-at-require-statement.feature
+++ b/features/navigation/going-to-file-at-require-statement.feature
@@ -44,4 +44,3 @@ Scenario: Going to gem at line: require 'foo'
   And I turn on projectile-mode
   And I run "projectile-rails-goto-file-at-point"
   Then I am in a dired buffer "vendor/foo/"
-

--- a/features/navigation/going-to-javascript-from-assets-pipeline-manifest.feature
+++ b/features/navigation/going-to-javascript-from-assets-pipeline-manifest.feature
@@ -1,5 +1,5 @@
 Feature: Going to a javascript file from assets pipeline manifest
-  
+
 Scenario: Going to file from: //= require user
     Given file "app/assets/javascripts/user.js" exists
     And I open the app file "app/assets/javascripts/application.js"

--- a/features/navigation/going-to-stylesheet-from-assets-pipeline-manifest.feature
+++ b/features/navigation/going-to-stylesheet-from-assets-pipeline-manifest.feature
@@ -1,5 +1,5 @@
 Feature: Going to a stylesheet file from assets pipeline manifest
-  
+
 Scenario: Going to file from: *= require user
     Given file "app/assets/stylesheets/user.css" exists
     And I open the app file "app/assets/stylesheets/application.css"

--- a/features/navigation/goto-rails-universal-file.feature
+++ b/features/navigation/goto-rails-universal-file.feature
@@ -2,27 +2,27 @@ Feature: Going to the files that each Rails project has
   In order to go to universal files fast
   As a user
   I want to be able to run projectile-rails command and go to the file
-  
+
 Background:
   Given file "app/models/user.rb" exists
   And I open the app file "app/models/user.rb"
   And I turn on projectile-mode
-  
+
 Scenario: Going to Gemfile
   And file "Gemfile" exists
   When I run "projectile-rails-goto-gemfile"
   Then I am in file "Gemfile"
-  
+
 Scenario: Going to schema
   And file "db/schema.rb" exists
   When I run "projectile-rails-goto-schema"
   Then I am in file "db/schema.rb"
-  
+
 Scenario: Going to routes
   And file "config/routes.rb" exists
   When I run "projectile-rails-goto-routes"
   Then I am in file "config/routes.rb"
-  
+
 Scenario: Going to spec_helper
   And file "spec/spec_helper.rb" exists
   When I run "projectile-rails-goto-spec-helper"

--- a/features/rails-server.feature
+++ b/features/rails-server.feature
@@ -1,5 +1,5 @@
 Feature: Running rails server command
-  
+
 Scenario: Running rails server
   Given file "app/controllers/users_controller.rb" exists
   And file "app/views/users/_user.html.erb" exists

--- a/features/rake.feature
+++ b/features/rake.feature
@@ -2,7 +2,7 @@ Feature: Using rake
   In order to use rake
   As a user
   I want to be able to run a rake tasks from Emacs
-  
+
 Background:
   Given I open the app file "app/models/user.rb"
   And I turn on projectile-mode
@@ -11,7 +11,7 @@ Scenario: Running about task
   When I run command "projectile-rails-rake" selecting "about"
   And I switch to buffer "*projectile-rails-compilation*"
   Then I should see "bundle exec rake about"
-  
+
 Scenario: Running about task when spring is running
   And spring is running
   When I run command "projectile-rails-rake" selecting "about"
@@ -23,10 +23,9 @@ Scenario: Running about task when zeus is running
   When I run command "projectile-rails-rake" selecting "about"
   And I switch to buffer "*projectile-rails-compilation*"
   Then I should see "zeus rake about"
-  
+
 Scenario: Using caching
   And the cache file with projectile-rails task exists
   When I run command "projectile-rails-rake" selecting "projectile-rails"
   And I switch to buffer "*projectile-rails-compilation*"
   Then I should see "bundle exec rake projectile-rails"
-

--- a/features/turning-on-and-off.feature
+++ b/features/turning-on-and-off.feature
@@ -7,7 +7,7 @@ Feature: Enabling projectile-rails mode
     Given I open the app file "app/models/user.rb"
     And I turn on projectile-mode
     Then projectile-rails should be turned on
-    
+
   Scenario: Turning off
     Given I open the app file "app/models/user.rb"
     When I turn on projectile-mode

--- a/projectile-rails.el
+++ b/projectile-rails.el
@@ -534,7 +534,7 @@ Returns a hash table with keys being short names and values being relative paths
 (defun projectile-rails-sanitize-and-goto-file (dir name &optional ext)
   "Calls `projectile-rails-goto-file' with passed arguments sanitizing them before."
   (projectile-rails-goto-file
-   (concat 
+   (concat
     (projectile-rails-sanitize-dir-name dir) (projectile-rails-declassify name) ext)))
 
 (defun projectile-rails-goto-file (filepath)
@@ -581,7 +581,7 @@ Returns a hash table with keys being short names and values being relative paths
 
 	  ((string-match-p "\\_<require\\_>" line)
 	   (projectile-rails-goto-gem (thing-at-point 'filename)))
-	  
+
 	  ((not (string-match-p "^[A-Z]" name))
 	   (projectile-rails-sanitize-and-goto-file "app/models/" (singularize-string name) ".rb"))
 

--- a/test/projectile-rails-goto-template-at-point-test.el
+++ b/test/projectile-rails-goto-template-at-point-test.el
@@ -79,4 +79,3 @@
 		  (projectile-rails-template-dir "index"))))
        )
  )
-


### PR DESCRIPTION
Pretty much self-explanatory... when in a model, currently `C-c r N` works but then `C-c r M` doesn't.

Please review the regex it's was written quickly.
