### PR TITLE
Fallback when current-resource return current file

### DIFF
--- a/projectile-rails.el
+++ b/projectile-rails.el
@@ -214,10 +214,15 @@
 The binded variables are \"singular\" and \"plural\"."
   `(let* ((singular (projectile-rails-current-resource-name))
           (plural (pluralize-string singular))
+          (abs-current-file (buffer-file-name (current-buffer)))
+          (current-file (if abs-current-file
+                            (file-relative-name abs-current-file
+                                                (projectile-project-root))))
           (files (--filter
-                  (string-match-p (s-lex-format ,re) it)
+                  (and (string-match-p (s-lex-format ,re) it)
+                       (not (string= current-file it)))
                   (projectile-dir-files (projectile-expand-root ,dir)))))
-     (if (eq files '())
+     (if (null files)
          (funcall ,fallback)
        (projectile-rails-goto-file
         (if (= (length files) 1)


### PR DESCRIPTION
As mentioned in #22, when the current file is a model, if the user calls
`projectile-rails-find-current-model`, we should list all the
models. Currently nothing will be done.

Now, with the feature described in #22 implemented, key-chord users can
define suck key bindings:

``` el
(key-chord-define 'projectile-rails-mode-map "jm" 'projectile-rails-find-current-model)
(key-chord-define 'projectile-rails-mode-map "jc" 'projectile-rails-find-current-controller)
(key-chord-define 'projectile-rails-mode-map "jv" 'projectile-rails-find-current-view)
(key-chord-define 'projectile-rails-mode-map "jh" 'projectile-rails-find-current-helper)
```

This makes it extremely fast to toggle among current resources.
