### PR TITLE
Add snippet for new ActiveSupport::Concern module files

### DIFF
--- a/projectile-rails.el
+++ b/projectile-rails.el
@@ -563,7 +563,7 @@ The binded variable is \"filename\"."
     (yas-expand-snippet
      (cond ((string-match "app/[^/]+/concerns/\\(.+\\)\\.rb$" name)
             (format
-             "module %s\nextend ActiveSupport::Concern\n$1\nend"
+             "module %s\n  extend ActiveSupport::Concern\n$1\nend"
              (s-join "::" (projectile-rails-classify (match-string 1 name)))))
            ((string-match "app/controllers/\\(.+\\)\\.rb$" name)
             (format


### PR DESCRIPTION
This pull request extends projectile-rails-expand-corresponding-snippet by adding a snippet for new files in app/*/concerns/ with a basic ActiveSupport::Concern template.

See http://api.rubyonrails.org/classes/ActiveSupport/Concern.html and https://signalvnoise.com/posts/3372-put-chubby-models-on-a-diet-with-concerns for details about concerns in Rails 4.
