### PR TITLE
Fix jbuilder and builder view cannot be found

### DIFF
--- a/projectile-rails.el
+++ b/projectile-rails.el
@@ -140,7 +140,7 @@
   "Face to be used for higlighting rails the keywords")
 
 (defcustom projectile-rails-views-re
-  "\\.\\(?:html\\|erb\\|haml\\|js\\|slim\\|json\\|coffee\\|css\\)$"
+  "\\.\\(?:html\\|erb\\|haml\\|js\\|slim\\|json\\|coffee\\|css\\|j?builder\\)$"
   "Regexp for filtering for view files"
   :group 'projectile-rails
   :type 'string)


### PR DESCRIPTION
Add projectile-rails-guard.

add function to run guard just inside emacs.
