### PR TITLE
Support goto-file-at-point for CoffeeScript

### DIFF
--- a/projectile-rails.el
+++ b/projectile-rails.el
@@ -666,6 +666,9 @@ The bound variable is \"filename\"."
           ((string-match-p "^\\s-*//= require .+\\s-*$" line)
            (projectile-rails-goto-asset-at-point projectile-rails-javascript-dirs))
 
+          ((string-match-p "^\\s-*\\#= require .+\\s-*$" line)
+           (projectile-rails-goto-asset-at-point projectile-rails-javascript-dirs))
+
           ((string-match-p "^\\s-*\\*= require .+\\s-*$" line)
            (projectile-rails-goto-asset-at-point projectile-rails-stylesheet-dirs))
 


### PR DESCRIPTION
I use Sprockets and CoffeeScript, so I would like to support `projectile-rails-goto-file-at-point` for CoffeeScript, such as below `require` code.

```coffee
#= require foo
```

See: https://github.com/sstephenson/sprockets#supported-comment-types