### PR TITLE
Add option to use factory_girl instead of fixtures

### DIFF
--- a/features/navigation/finding-fixture.feature
+++ b/features/navigation/finding-fixture.feature
@@ -1,8 +1,98 @@
+@finding-fixtures
 Feature: Finding a fixture file
 
-Scenario: Finding the users fixtures
+Scenario: Finding the users fixtures when using test
   Given I open the app file "app/models/user.rb"
+  And directory "test/fixtures/" exists
   And file "test/fixtures/users.yml" exists
   And I turn on projectile-mode
   When I run command "projectile-rails-find-fixture" selecting "users"
   Then I am in file "test/fixtures/users.yml"
+
+Scenario: Finding the users fixtures when using rspec
+  Given I open the app file "app/models/user.rb"
+  And directory "spec/fixtures/" exists
+  And file "spec/fixtures/users.yml" exists
+  And I turn on projectile-mode
+  When I run command "projectile-rails-find-fixture" selecting "users"
+  Then I am in file "spec/fixtures/users.yml"
+
+Scenario: Finding the users factories when using test
+  Given I open the app file "app/models/user.rb"
+  And directory "test/factories/" exists
+  And file "test/factories/users.rb" exists
+  And I turn on projectile-mode
+  When I run command "projectile-rails-find-fixture" selecting "users"
+  Then I am in file "test/factories/users.rb"
+
+Scenario: Finding the users factories when using rspec
+  Given I open the app file "app/models/user.rb"
+  And directory "spec/factories/" exists
+  And file "spec/factories/users.rb" exists
+  And I turn on projectile-mode
+  When I run command "projectile-rails-find-fixture" selecting "users"
+  Then I am in file "spec/factories/users.rb"
+
+Scenario: Finding the users fabricator when using test
+  Given I open the app file "app/models/user.rb"
+  And directory "test/fabricators/" exists
+  And file "test/fabricators/user_fabricator.rb" exists
+  And I turn on projectile-mode
+  When I run command "projectile-rails-find-fixture" selecting "user"
+  Then I am in file "test/fabricators/user_fabricator.rb"
+
+Scenario: Finding the users fabricator when using rspec
+  Given I open the app file "app/models/user.rb"
+  And directory "spec/fabricators/" exists
+  And file "spec/fabricators/user_fabricator.rb" exists
+  And I turn on projectile-mode
+  When I run command "projectile-rails-find-fixture" selecting "user"
+  Then I am in file "spec/fabricators/user_fabricator.rb"
+
+Scenario: Finding the current fixture when using test
+  Given I open the app file "app/models/user.rb"
+  And directory "test/fixtures/" exists
+  And file "test/fixtures/users.yml" exists
+  And I turn on projectile-mode
+  When I run "projectile-rails-find-current-fixture"
+  Then I am in file "test/fixtures/users.yml"
+
+Scenario: Finding the current fixture when using rspec
+  Given I open the app file "app/models/user.rb"
+  And directory "spec/fixtures/" exists
+  And file "spec/fixtures/users.yml" exists
+  And I turn on projectile-mode
+  When I run "projectile-rails-find-current-fixture"
+  Then I am in file "spec/fixtures/users.yml"
+
+Scenario: Finding the current factory when using test
+  Given I open the app file "app/models/user.rb"
+  And directory "test/factories/" exists
+  And file "test/factories/users.rb" exists
+  And I turn on projectile-mode
+  When I run "projectile-rails-find-current-fixture"
+  Then I am in file "test/factories/users.rb"
+
+Scenario: Finding the current factory when using rspec
+  Given I open the app file "app/models/user.rb"
+  And directory "spec/factories/" exists
+  And file "spec/factories/users.rb" exists
+  And I turn on projectile-mode
+  When I run "projectile-rails-find-current-fixture"
+  Then I am in file "spec/factories/users.rb"
+
+Scenario: Finding the current fabricator when using test
+  Given I open the app file "app/models/user.rb"
+  And directory "test/fabricators/" exists
+  And file "test/fabricators/user_fabricator.rb" exists
+  And I turn on projectile-mode
+  When I run "projectile-rails-find-current-fixture"
+  Then I am in file "test/fabricators/user_fabricator.rb"
+
+Scenario: Finding the current fabricator when using rspec
+  Given I open the app file "app/models/user.rb"
+  And directory "spec/fabricators/" exists
+  And file "spec/fabricators/user_fabricator.rb" exists
+  And I turn on projectile-mode
+  When I run "projectile-rails-find-current-fixture"
+  Then I am in file "spec/fabricators/user_fabricator.rb"

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -44,6 +44,14 @@ end")
   (save-buffer)
   )
 
+(defun delete-fixture-files ()
+  (let* ((files '("spec/fixtures/" "spec/factories/" "spec/fabricators/"
+                 "test/fixtures/" "test/factories/" "test/fabricators/"))
+         (fullpath (--map (f-expand it projectile-rails-test-app-path) files))
+         (file-in-directory (first (--filter (f-exists? it) fullpath))))
+    (when file-in-directory
+      (f-delete file-in-directory t))))
+
 (require 'projectile-rails)
 (require 'espuds)
 (require 'ert)
@@ -88,7 +96,6 @@ end")
                      "spec/controllers/"
                      "spec/controllers/admin/"
                      "test/"
-                     "test/fixtures/"
                      "test/controllers/"
                      "features/"
                      "tmp/"
@@ -135,3 +142,7 @@ end")
  (start-process-shell-command "spring" nil "spring stop")
  (delete-directory projectile-rails-test-app-path t)
  )
+
+(After "@finding-fixtures"
+       (delete-fixture-files)
+)

--- a/projectile-rails.el
+++ b/projectile-rails.el
@@ -189,6 +189,11 @@
 (defcustom projectile-rails-discover-bind "s-r"
   "The :bind option that will be passed `discover-add-context-menu' if available")
 
+(defcustom projectile-rails-use-factory-girl nil
+  "if not nil `projectile-rails-find-fixture' will find factory_girl factories instead."
+  :group 'projectile-rails
+  :type 'boolean)
+
 (defvar projectile-rails-extracted-region-snippet
   '(("erb"  . "<%%= render '%s' %%>")
     ("haml" . "= render '%s'")
@@ -364,10 +369,15 @@ The bound variable is \"filename\"."
 
 (defun projectile-rails-find-fixture ()
   (interactive)
-  (projectile-rails-find-resource
-   "fixture: "
-   `(("test/fixtures/" "test/fixtures/\\(.+\\)\\.yml$"))
-   "test/fixtures/${filename}.yml"))
+  (if projectile-rails-use-factory-girl
+      (projectile-rails-find-resource
+       "factory: "
+       `(("spec/factories/" "spec/factories/\\(.+\\)\\.rb$"))
+       "spec/factories/${filename}.rb")
+    (projectile-rails-find-resource
+     "fixture: "
+     `(("test/fixtures/" "test/fixtures/\\(.+\\)\\.yml$"))
+     "test/fixtures/${filename}.yml")))
 
 (defun projectile-rails-find-feature ()
   (interactive)
@@ -468,10 +478,15 @@ The bound variable is \"filename\"."
 
 (defun projectile-rails-find-current-fixture ()
   (interactive)
-  (projectile-rails-find-current-resource
-   "test/fixtures/"
-   "/${plural}\\.yml$"
-   'projectile-rails-find-fixture))
+  (if projectile-rails-use-factory-girl
+      (projectile-rails-find-current-resource
+       "spec/factories/"
+       "/${plural}\\.rb$"
+       'projectile-rails-find-fixture)
+    (projectile-rails-find-current-resource
+     "test/fixtures/"
+     "/${plural}\\.yml$"
+     'projectile-rails-find-fixture)))
 
 (defun projectile-rails-find-current-migration ()
   (interactive)
@@ -492,7 +507,8 @@ The bound variable is \"filename\"."
                            "app/assets/stylesheets/\\(?:.+/\\)*\\(.+\\)\\.css\\(?:\\.scss\\)$"
                            "db/migrate/.*create_\\(.+\\)\\.rb$"
                            "spec/.*/\\([a-z_]+?\\)\\(?:_controller\\)?_spec\\.rb$"
-                           "test/fixtures/\\(.+\\)\\.yml$")
+                           "test/fixtures/\\(.+\\)\\.yml$"
+                           "spec/factories/\\(.+\\)\\.rb$")
                until (string-match re file-name)
                finally return (match-string 1 file-name))))))
 

--- a/projectile-rails.el
+++ b/projectile-rails.el
@@ -189,11 +189,6 @@
 (defcustom projectile-rails-discover-bind "s-r"
   "The :bind option that will be passed `discover-add-context-menu' if available")
 
-(defcustom projectile-rails-use-factory-girl nil
-  "if not nil `projectile-rails-find-fixture' will find factory_girl factories instead."
-  :group 'projectile-rails
-  :type 'boolean)
-
 (defvar projectile-rails-extracted-region-snippet
   '(("erb"  . "<%%= render '%s' %%>")
     ("haml" . "= render '%s'")
@@ -367,17 +362,28 @@ The bound variable is \"filename\"."
    '(("test/" "test/\\(.+\\)_test\\.rb$"))
    "test/${filename}_test.rb"))
 
+(defvar projectile-rails-factory-dirs
+  '(("fixture: " "test/fixtures/" "test/fixtures/\\(.+\\)\\.yml$"
+     "test/fixtures/${filename}.yml")
+    ("fixture: " "spec/fixtures/" "spec/fixtures/\\(.+\\).yml$"
+     "spec/fixtures/${filename}.yml")
+    ("factory: " "test/factories/" "test/factories/\\(.+\\)\\.rb$"
+     "test/factories/${filename}.rb")
+    ("factory: " "spec/factories/" "sepc/factories/\\(.+\\)\\.rb$"
+     "spec/factories/${filename}.rb")
+    ("fabrication: " "test/fabricators/" "test/fabricators/\\(.+\\)\\.rb$"
+     "test/fabricators/${filename}.rb")
+    ("fabrication: " "spec/fabricators/" "spec/fabricators/\\(.+\\)\\.rb$"
+     "spec/fabricators/${filename}.rb")))
+
+
 (defun projectile-rails-find-fixture ()
   (interactive)
-  (if projectile-rails-use-factory-girl
-      (projectile-rails-find-resource
-       "factory: "
-       `(("spec/factories/" "spec/factories/\\(.+\\)\\.rb$"))
-       "spec/factories/${filename}.rb")
+  (let ((fixture-dir (first projectile-rails-factory-dirs)))
     (projectile-rails-find-resource
-     "fixture: "
-     `(("test/fixtures/" "test/fixtures/\\(.+\\)\\.yml$"))
-     "test/fixtures/${filename}.yml")))
+     (nth 0 fixture-dir)
+     (list (-select-by-indices '(1 2) fixture-dir))
+     (nth 3 fixture-dir))))
 
 (defun projectile-rails-find-feature ()
   (interactive)
@@ -885,6 +891,12 @@ If file does not exist and ASK in not nil it will ask user to proceed."
   (setq-local
    projectile-rails-stylesheet-dirs
    (--filter (file-exists-p (projectile-expand-root it)) projectile-rails-stylesheet-dirs)))
+
+
+(defun projectile-rails-set-factory-dir ()
+  (setq-local
+   projectile-rails-factory-dir
+   (--filter (file-exists-p (projectile-expand-root (nth 1 it))) projectile-rails-factory-dirs)))
 
 (defvar projectile-rails-mode-goto-map
   (let ((map (make-sparse-keymap)))


### PR DESCRIPTION
I'm not sure if this is up to standard. Simplest solution is to add an `if` statement for `projectile-rails-find-fixture`, while having `projectile-rails-find-factory` is much better but requires either an `if` statement inside `projectile-rails-command-map` or having two different maps (also same applies to easy-menu). Let me know what you think.