### PR TITLE
Support goto-file-at-point for Sass

### DIFF
--- a/projectile-rails.el
+++ b/projectile-rails.el
@@ -672,6 +672,9 @@ The bound variable is \"filename\"."
           ((string-match-p "^\\s-*\\*= require .+\\s-*$" line)
            (projectile-rails-goto-asset-at-point projectile-rails-stylesheet-dirs))
 
+          ((string-match-p "^\\s-*\\@import .+\\s-*$" line)
+           (projectile-rails-goto-asset-at-point projectile-rails-stylesheet-dirs))
+
           ((string-match-p "\\_<require_relative\\_>" line)
            (projectile-rails-ff (expand-file-name (concat (thing-at-point 'filename) ".rb"))))
 


### PR DESCRIPTION
I would like to support `@import` syntax in `projectile-rails-goto-file-at-point` for Sass. I think the syntax is widely used in Rails projects.
See: http://pivotallabs.com/structure-your-sass-files-with-import/