### PR TITLE
Add tab completion to generate and destroy

### DIFF
--- a/features/destroy.feature
+++ b/features/destroy.feature
@@ -30,3 +30,11 @@ Scenario: Running destroy model airplane when zeus is running
   When I run command "projectile-rails-destroy" inputting "model airplane"
   And I switch to buffer "*projectile-rails-compilation*"
   Then I should see "zeus destroy model airplane"
+
+Scenario: Running destroy model airplane with completion
+  Given I open the app file "app/models/user.rb"
+  And I turn on projectile-mode
+  When I run projectile-rails-destroy inputting "mo" and selecting "airplane"
+  And I switch to buffer "*projectile-rails-compilation*"
+  Then I should see "bundle exec rails destroy model airplane"
+

--- a/features/generate.feature
+++ b/features/generate.feature
@@ -46,3 +46,87 @@ Scenario: Using buttons
   When I place the cursor between "conflict  spe" and "c"
   And I press "RET"
   Then I am in file "spec/spec_helper.rb"
+
+Scenario: Running generate with input 'as' should generate assets
+  Given I open the app file "app/models/user.rb"
+  And I turn on projectile-mode
+  When I run projectile-rails-generate inputting "as" and the name "post"
+  And I switch to buffer "*projectile-rails-generate*"
+  Then I should see "bundle exec rails generate assets post"
+
+Scenario: Running generate with input 'co' should generate a controller
+  Given I open the app file "app/models/user.rb"
+  And I turn on projectile-mode
+  When I run projectile-rails-generate inputting "co" and the name "posts"
+  And I switch to buffer "*projectile-rails-generate*"
+  Then I should see "bundle exec rails generate controller post"
+
+Scenario: Running generate with input 'ge' should generate a generator
+  Given I open the app file "app/models/user.rb"
+  And I turn on projectile-mode
+  When I run projectile-rails-generate inputting "ge" and the name "post"
+  And I switch to buffer "*projectile-rails-generate*"
+  Then I should see "bundle exec rails generate generator post"
+
+Scenario: Running generate with input 'he' should generate a helper
+  Given I open the app file "app/models/user.rb"
+  And I turn on projectile-mode
+  When I run projectile-rails-generate inputting "he" and the name "post"
+  And I switch to buffer "*projectile-rails-generate*"
+  Then I should see "bundle exec rails generate helper post"
+
+Scenario: Running generate with input 'int' should generate an integration_test
+  Given I open the app file "app/models/user.rb"
+  And I turn on projectile-mode
+  When I run projectile-rails-generate inputting "int" and the name "post"
+  And I switch to buffer "*projectile-rails-generate*"
+  Then I should see "bundle exec rails generate integration_test post"
+
+Scenario: Running generate with input 'jo' should generate a job
+  Given I open the app file "app/models/user.rb"
+  And I turn on projectile-mode
+  When I run projectile-rails-generate inputting "jo" and the name "post"
+  And I switch to buffer "*projectile-rails-generate*"
+  Then I should see "bundle exec rails generate job post"
+
+Scenario: Running generate with input 'ma' should generate a mailer
+  Given I open the app file "app/models/user.rb"
+  And I turn on projectile-mode
+  When I run projectile-rails-generate inputting "ma" and the name "post"
+  And I switch to buffer "*projectile-rails-generate*"
+  Then I should see "bundle exec rails generate mailer post"
+
+Scenario: Running generate with input 'mig' shuold generate a migration
+  Given I open the app file "app/models/user.rb"
+  And I turn on projectile-mode
+  When I run projectile-rails-generate inputting "mig" and the name "post"
+  And I switch to buffer "*projectile-rails-generate*"
+  Then I should see "bundle exec rails generate migration post"
+
+Scenario: Running generate with input 'mo' should generate a model
+  Given I open the app file "app/models/user.rb"
+  And I turn on projectile-mode
+  When I run projectile-rails-generate inputting "mo" and the name "post"
+  And I switch to buffer "*projectile-rails-generate*"
+  Then I should see "bundle exec rails generate model post"
+
+Scenario: Runniing generate with input 're' should generate a resource
+  Given I open the app file "app/models/user.rb"
+  And I turn on projectile-mode
+  When I run projectile-rails-generate inputting "re" and the name "post"
+  And I switch to buffer "*projectile-rails-generate*"
+  Then I should see "bundle exec rails generate resource post"
+
+Scenario: Running generate with input 'sc' should generate a scaffold
+  Given I open the app file "app/models/user.rb"
+  And I turn on projectile-mode
+  When I run projectile-rails-generate inputting "sc" and the name "post"
+  And I switch to buffer "*projectile-rails-generate*"
+  Then I should see "bundle exec rails generate scaffold post"
+
+Scenario: Running generate with input 'ta' should generate a task
+  Given I open the app file "app/models/user.rb"
+  And I turn on projectile-mode
+  When I run projectile-rails-generate inputting "ta" and the name "post"
+  And I switch to buffer "*projectile-rails-generate*"
+  Then I should see "bundle exec rails generate task post"

--- a/features/step-definitions/projectile-rails-steps.el
+++ b/features/step-definitions/projectile-rails-steps.el
@@ -22,6 +22,32 @@
     (And (s-lex-format "I type \"${argument}\""))
     (And "I execute the action chain")))
 
+
+(When "^I run projectile-rails-destroy inputting \"\\(.+\\)\" and selecting \"\\(.+\\)\""
+  (lambda (partial-input selection)
+    (When "I start an action chain")
+    (When "I press \"M-x\"")
+    (And "I type \"projectile-rails-destroy\"")
+    (When "I press \"<return>\"")
+    (And (s-lex-format "I type \"${partial-input}\""))
+    (When "I press \"<tab>\"")
+    (And (s-lex-format "I type \"${selection}\""))
+    (When "I press \"<return>\"")
+    (And "I execute the action chain")))
+
+(When "^I run projectile-rails-generate inputting \"\\(.+\\)\" and the name \"\\(.+\\)\""
+  (lambda (partial-input name)
+    (When "I start an action chain")
+    (When "I press \"M-x\"")
+    (And "I type \"projectile-rails-generate\"")
+    (When "I press \"<return>\"")
+    (And (s-lex-format "I type \"${partial-input}\""))
+    (When "I press \"<tab>\"")
+    (And (s-lex-format "I type \"${name}\""))
+    (When "I press \"<return>\"")
+    (When "I execute the action chain")))
+
+
 (When "^I run command \"\\(.+\\)\" \\(?:selecting\\|inputting\\) \"\\(.+\\)\" and confirm$"
   (lambda (command argument)
     (When "I start an action chain")

--- a/projectile-rails.el
+++ b/projectile-rails.el
@@ -205,7 +205,8 @@
   "The path to the Zeus socket file")
 
 (defvar projectile-rails-generators
-  '(("assets" (("app/assets/javascripts/" "app/assets/javascripts/\\(.+\\)\\.coffee$")))
+  '(("assets" (("app/assets/"
+                "app/assets/\\(?:stylesheets\\|javascripts\\)/\\(.+?\\)\\..+$")))
     ("controller" (("app/controllers/" "app/controllers/\\(.+\\)_controller\\.rb$")))
     ("generator" (("lib/generator/" "lib/generators/\\(.+\\)$")))
     ("helper" (("app/helpers/" "app/helpers/\\(.+\\)_helper.rb$")))


### PR DESCRIPTION
Hi,
Always bugged me that using the command line was a better experience than using `projectile-rails-generate` so I made it better. generate now completes common generators and destroy when you select a generator it give you choices of available resources (this doesn't change the old behavior).

Destroy tests are lacking because I couldn't figure out how test the choices of resource you get once you choose a generator.

I'm not good at elisp so if this can be improved please let me know how.