### PR TITLE
Add helpers to find serializers

### DIFF
--- a/projectile-rails.el
+++ b/projectile-rails.el
@@ -357,6 +357,13 @@ The bound variable is \"filename\"."
    '(("app/controllers/" "/controllers/\\(.+\\)_controller\\.rb$"))
    "app/controllers/${filename}_controller.rb"))
 
+(defun projectile-rails-find-serializer ()
+  (interactive)
+  (projectile-rails-find-resource
+   "serializer: "
+   '(("app/serializers/" "/serializers/\\(.+\\)_serializer\\.rb$"))
+   "app/serializers/${filename}_serializer.rb"))
+
 (defun projectile-rails-find-view ()
   (interactive)
   (projectile-rails-find-resource
@@ -486,6 +493,12 @@ The bound variable is \"filename\"."
   (projectile-rails-find-current-resource "app/controllers/"
                                           "app/controllers/\\(.*${plural}\\)_controller\\.rb$"
                                           'projectile-rails-find-controller))
+
+(defun projectile-rails-find-current-serializer ()
+  (interactive)
+  (projectile-rails-find-current-resource "app/serializers/"
+                                          "app/serializers/\\(.*${singular}\\)_serializer\\.rb$"
+                                          'projectile-rails-find-serializer))
 
 (defun projectile-rails-find-current-view ()
   (interactive)


### PR DESCRIPTION
API-based Rails applications depend often on serializers instead of views.  Furthermore, Rails 5 is including Rails API along with ActiveModel::Serializers out of the box.

I threw together a couple functions to help me find them rapidly, and I thought I'd offer them upstream.

Admittedly, this is so far rather naive.  It only has the parts that are directly relevant to me, i.e. the finders.  It also doesn't include default keymaps--I'm using evil at the moment so I have no opinion on what they should be.

What can I add to this to make it helpful and fit into the current infrastructure?