### PR TITLE
Specify minimum Emacs version

### DIFF
--- a/projectile-rails.el
+++ b/projectile-rails.el
@@ -6,7 +6,7 @@
 ;; URL:               https://github.com/asok/projectile-rails
 ;; Version:           0.5.0
 ;; Keywords:          rails, projectile
-;; Package-Requires:  ((projectile "0.12.0") (inflections "1.1") (inf-ruby "2.2.6") (f "0.13.0") (rake "0.3.2"))
+;; Package-Requires:  ((emacs "24.3") (projectile "0.12.0") (inflections "1.1") (inf-ruby "2.2.6") (f "0.13.0") (rake "0.3.2"))
 
 ;; This file is NOT part of GNU Emacs.
 


### PR DESCRIPTION
setq-local and user-error was introduced at Emacs 24.3.