### PR TITLE
Relaxing controller finding

### DIFF
--- a/projectile-rails.el
+++ b/projectile-rails.el
@@ -364,7 +364,7 @@ The bound variable is \"filename\"."
   (interactive)
   (projectile-rails-find-resource
    "controller: "
-   '(("app/controllers/" "/controllers/\\(.+\\)_controller\\.rb$"))
+   '(("app/controllers/" "/controllers/\\(.+?\\)\\(_controller\\)?\\.rb$"))
    "app/controllers/${filename}_controller.rb"))
 
 (defun projectile-rails-find-serializer ()


### PR DESCRIPTION
In a larger Rails app, it's not uncommon to want to find something
that's in the controllers directory but that doesn't match the pattern
`app/controllers/something_controller.rb`. Such a file could be a mixin,
or a namespaced controller, so it seems sufficient to just look in the
controllers directory, as with finding models.