### PR TITLE
Extract resource names from Minitest's controller tests

### DIFF
--- a/projectile-rails.el
+++ b/projectile-rails.el
@@ -598,6 +598,7 @@ The bound variable is \"filename\"."
     ,(concat "/app/assets/stylesheets/\\(?:.+/\\)?\\(.+\\)" projectile-rails-stylesheet-re)
     "/db/migrate/.*create_\\(.+\\)\\.rb\\'"
     "/spec/.*/\\([a-z_]+?\\)\\(?:_controller\\)?_spec\\.rb\\'"
+    "/test/.*/\\([a-z_]+?\\)\\(?:_controller\\)?_test\\.rb\\'"
     "/\\(?:test\\|spec\\)/\\(?:fixtures\\|factories\\|fabricators\\)/\\(.+?\\)\\(?:_fabricator\\)?\\.\\(?:yml\\|rb\\)\\'")
   "List of regexps for extracting a resource name from a buffer file name."
   :group 'projectile-rails

--- a/test/projectile-rails-current-resource-name-test.el
+++ b/test/projectile-rails-current-resource-name-test.el
@@ -59,4 +59,14 @@
        (expect "user"
                (with-mock
                 (stub buffer-file-name => "/spec/controllers/foo/bar/users_controller_spec.rb")
+                (projectile-rails-current-resource-name))))
+ (desc "non-namespaced controller test"
+       (expect "user"
+               (with-mock
+                (stub buffer-file-name => "/test/controllers/users_controller_test.rb")
+                (projectile-rails-current-resource-name))))
+ (desc "namespaced controller test"
+       (expect "user"
+               (with-mock
+                (stub buffer-file-name => "/test/controllers/foo/bar/users_controller_test.rb")
                 (projectile-rails-current-resource-name)))))


### PR DESCRIPTION
Integration tests seem broken at the moment, but I'm sure it's not me.