### PR TITLE
Root constant support for goto-file-at-point

### DIFF
--- a/projectile-rails.el
+++ b/projectile-rails.el
@@ -949,7 +949,7 @@ The bound variable is \"filename\"."
           ((string-match-p "^[a-z]" name)
            (projectile-rails-find-constant (singularize-string name)))
 
-          ((string-match-p "^[A-Z]" name)
+          ((string-match-p "^\\(::\\)?[A-Z]" name)
            (projectile-rails-goto-constant-at-point)))))
 
 (defun projectile-rails-goto-constant-at-point ()
@@ -970,7 +970,6 @@ The bound variable is \"filename\"."
 
 (defun projectile-rails-find-constant (name)
   (let* ((code-dirs (-filter #'f-exists? (-map #'projectile-rails-expand-root (projectile-rails--code-directories))))
-         (file-name (format "%s.rb" (projectile-rails-declassify name)))
          (list-parent-dirs (lambda (some-file)
                              (let ((parent-dirs '()))
                                (f-traverse-upwards (lambda (parent-dir)
@@ -978,19 +977,28 @@ The bound variable is \"filename\"."
                                                      (equal (f-slash (f-canonical (projectile-rails-root))) (f-slash (f-canonical parent-dir))))
                                                    (f-dirname some-file))
                                parent-dirs)))
-         (lookup-dirs (-flatten (list
-                                 ;; Look in current file namespace
-                                 (f-no-ext buffer-file-name)
-                                 ;; Look in local namespace hierarchy
-                                 (funcall list-parent-dirs buffer-file-name)
-                                 ;; Look in code directories
-                                 code-dirs)))
-         (lookup-paths (--map (f-join it file-name)
+         (file-name (format "%s.rb" (projectile-rails-declassify name)))
+         (lookup-dirs (if (f-absolute? file-name)
+                          ;; If top-level constant (e.g. ::Classname), i.e. derived filename (/classname) starts with a "/", then:
+                          ;; Look only in code directories
+                          code-dirs
+                        (-flatten (list
+                                   ;; Otherwise (relative constant):
+                                   ;; 1. Look in current file namespace
+                                   (f-no-ext buffer-file-name)
+                                   ;; 2. Look in local namespace hierarchy
+                                   (funcall list-parent-dirs buffer-file-name)
+                                   ;; 3. Look in code directories
+                                   code-dirs))))
+         ;; Strip leading "/" if present before generating lookup paths because it messes with f-join)
+         (relative-file-name (if (f-absolute? file-name)
+                                 (substring file-name 1)
+                               file-name))
+         (lookup-paths (--map (f-join it relative-file-name)
                               lookup-dirs))
          (choices
           (-uniq
            (-filter #'f-exists? lookup-paths))))
-
 
     (when (= (length choices) 0)
       (user-error "Could not find anything"))
@@ -1163,7 +1171,7 @@ If file does not exist and ASK in not nil it will ask user to proceed."
     (setq name (substring name 1 -1)))
   (when (s-starts-with? "./" name)
     (setq name (substring name 2)))
-  (when (or (s-starts-with? ":" name) (s-starts-with? "/" name))
+  (when (or (string-match-p "^:[^:]" name) (s-starts-with? "/" name))
     (setq name (substring name 1)))
   (when (s-ends-with? "," name)
     (setq name (substring name 0 -1)))

--- a/test/projectile-rails-test.el
+++ b/test/projectile-rails-test.el
@@ -9,7 +9,9 @@
        (expect "name"
                (projectile-rails-sanitize-name "'name'"))
        (expect "name"
-               (projectile-rails-sanitize-name "\"name\"")))
+               (projectile-rails-sanitize-name "\"name\""))
+       (expect "::Name"
+               (projectile-rails-sanitize-name "::Name")))
  (desc "projectile-rails-declassify"
        (expect "user"
                (projectile-rails-declassify "user"))
@@ -19,6 +21,8 @@
                (projectile-rails-declassify "UsersController"))
        (expect "admin/users_controller"
                (projectile-rails-declassify "Admin::UsersController"))
+       (expect "/admin/user"
+               (projectile-rails-declassify "::Admin::User"))
        (expect "users/index.html.erb"
                (projectile-rails-declassify "users/index.html.erb")))
  (desc "projectile-rails-hash-keys"


### PR DESCRIPTION
Makes `projectile-rails-goto-file-at-point` work with the class names that start with `::` (e.g.`::Constant::Name`)

As discussed in https://github.com/asok/projectile-rails/pull/103#issuecomment-248563054 for context