### PR TITLE
Docs: don't hook into deprecated projectile-mode-hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ The package name for [el-get](https://github.com/dimitri/el-get) is `projectile-
 
 ### Hooking up with Projectile
 
-To make it start alongside `projectile-mode`:
+To make it start in Ruby projects:
 
 ```el
-(add-hook 'projectile-mode-hook 'projectile-rails-on)
+(add-hook 'ruby-mode-hook 'projectile-rails-on)
 ```
 That will start it only if the current project is a Rails project (either application or an engine).
 

--- a/projectile-rails.el
+++ b/projectile-rails.el
@@ -29,9 +29,9 @@
 
 ;;; Commentary:
 ;;
-;; To make it start alongside projectile-mode:
+;; To make it start in Ruby projects:
 ;;
-;;    (add-hook 'projectile-mode-hook 'projectile-rails-on)
+;;    (add-hook 'ruby-mode-hook 'projectile-rails-on)
 ;;
 ;;; Code:
 


### PR DESCRIPTION
Since
https://github.com/bbatsov/projectile/commit/6986e435e64e2f4ee43bf8093c11e1da5fb266fa,
projectile has been made global, meaning that hooking into
`projectile-mode-hook` in order to activate projectile-rails-mode is no
longer possible.

It's probably inadvisable to follow suit with projectile-rails and make
it global too. Instead, I've updated the documentation to indicate
hooking into `ruby-mode` instead.

Fixes https://github.com/asok/projectile-rails/issues/105