### PR TITLE
Require cl explicitly

### DIFF
--- a/projectile-rails.el
+++ b/projectile-rails.el
@@ -35,6 +35,7 @@
 ;;
 ;;; Code:
 
+(require 'cl)
 (require 'projectile)
 (require 'inf-ruby)
 (require 'inflections)


### PR DESCRIPTION
This fixes a problem in my setup where I get errors such as this one when starting projectile-rails:

Looking at the current Travis breakage, I would expect this change to fix that too.

```
Error in post-command-hook (projectile-rails-global-mode-check-buffers): (void-variable for)
```

I honestly don't know enough about elisp to know if this is a proper fix for everyone. But to me it looks like the use of the `for` and `loop` keywords are failing because `cl` is not explicitly required.

