### PR TITLE
cache `root-relative-to-project-root`

### DIFF
--- a/projectile-rails.el
+++ b/projectile-rails.el
@@ -729,35 +729,33 @@ The mode of the output buffer will be `projectile-rails-compilation-mode'."
   (interactive "P")
   (rake arg 'projectile-rails-compilation-mode))
 
-(defun projectile-rails-root ()
-  "Returns rails root directory if this file is a part of a Rails application else nil"
-  (ignore-errors
-    (let ((root (projectile-locate-dominating-file default-directory projectile-rails-root-file)))
-      (when (file-exists-p (expand-file-name projectile-rails-verify-root-file root))
-        root))))
-
 (defvar projectile-rails-cache-data
   (make-hash-table :test 'equal)
   "A hash table that is used for caching information about the current project.")
 
 (defun projectile-rails-cache-key (key)
-  "Generates a cache key based on the current projectile project and the given KEY."
-  (concat (projectile-project-root) "-" key))
+  "Generate a cache key based on the current directory and the given KEY."
+  (format "%s-%s" default-directory key))
+
+(defun projectile-rails-root ()
+  "Returns rails root directory if this file is a part of a Rails application else nil"
+  (let* ((dir default-directory)
+         (cache-key (projectile-rails-cache-key "root"))
+         (cache-value (gethash cache-key projectile-rails-cache-data)))
+    (or cache-value
+        (ignore-errors
+          (let ((root (projectile-locate-dominating-file default-directory projectile-rails-root-file)))
+            (when (file-exists-p (expand-file-name projectile-rails-verify-root-file root))
+              (puthash cache-key root projectile-rails-cache-data)
+              root))))))
 
 (defun projectile-rails-root-relative-to-project-root ()
   "Return the location of the rails root relative to `projectile-project-root'."
-  (let* ((cache-key (projectile-rails-cache-key "rails-root-relative-to-project-root"))
-         (cache-value (gethash cache-key projectile-rails-cache-data)))
-    (or cache-value
-        (let ((rails-root (file-truename (projectile-rails-root)))
-              (project-root (projectile-project-root)))
-          (puthash
-           cache-key
-           (if (string-equal rails-root project-root)
-               ""
-             (substring rails-root (length (f-common-parent (list rails-root project-root)))))
-           projectile-rails-cache-data)
-          (projectile-rails-root-relative-to-project-root)))))
+  (let ((rails-root (file-truename (projectile-rails-root)))
+        (project-root (projectile-project-root)))
+    (if (string-equal rails-root project-root)
+        ""
+      (substring rails-root (length (f-common-parent (list rails-root project-root)))))))
 
 (defun projectile-rails-expand-root (dir)
   "Like `projectile-expand-root' but consider `projectile-rails-root'."


### PR DESCRIPTION
In projects of reasonable size, I've found that caching the value for
`projectile-rails-root-relative-to-project-root` yields significant
speed increases when using find-resource macros.

This seems (to me) to be a variable that is safe to cache, since it's
not likely to change in the lifetime of a project.

Let me know if this seems like a reasonable thing to include. Sorry I couldn't come up with any benchmarks beyond my own anecdotes