### PR TITLE
Require JSON for json-read-from-string

### DIFF
--- a/projectile-rails.el
+++ b/projectile-rails.el
@@ -41,6 +41,7 @@
 (require 'inflections)
 (require 'f)
 (require 'rake)
+(require 'json)
 
 (defgroup projectile-rails nil
   "Rails mode based on projectile"


### PR DESCRIPTION
json.el is needed in order to use json-read-from-string