### PR TITLE
Call `projectile-project-p` after ignored buffers were checked

### DIFF
--- a/projectile-rails.el
+++ b/projectile-rails.el
@@ -1154,7 +1154,7 @@ DIRS are directories where to look for assets."
 
 (defun projectile-rails--ignore-buffer-p ()
   "Returns t if `projectile-rails' should not be enabled for the current buffer"
-  (string-match-p "\\*\\(Minibuf-[0-9]+\\|helm mini\\)\\*" (buffer-name)))
+  (string-match-p "\\*\\(Minibuf-[0-9]+\\|helm mini\\|helm projectile\\)\\*" (buffer-name)))
 
 (defun projectile-rails-extract-region (partial-name)
   "Extract region to a partial called PARTIAL-NAME.
@@ -1516,8 +1516,8 @@ If file does not exist and ASK in not nil it will ask user to proceed."
 (defun projectile-rails-on ()
   "Enable `projectile-rails-mode' minor mode if this is a rails project."
   (when (and
-         (projectile-project-p)
          (not (projectile-rails--ignore-buffer-p))
+         (projectile-project-p)
          (projectile-rails-root))
     (projectile-rails-mode +1)))
 


### PR DESCRIPTION
This is a workaround to kill a bug which shows the same list of files when
switching projects with `helm-projectile`.
Reference: https://github.com/syl20bnr/spacemacs/issues/9277