### PR TITLE
Reduce byte compilation warnings

### DIFF
--- a/projectile-rails.el
+++ b/projectile-rails.el
@@ -259,6 +259,11 @@ When any of the files are found it means that this is a rails app."
   :group 'projectile-rails
   :type 'string)
 
+(defcustom projectile-rails-custom-dbconsole-command nil
+  "When set it will be use instead of a preloader as the command for running dbconsole."
+  :group 'projectile-rails
+  :type 'string)
+
 (defcustom projectile-rails-custom-server-command nil
   "When set it will be use instead of a preloader as the command for running server."
   :group 'projectile-rails

--- a/projectile-rails.el
+++ b/projectile-rails.el
@@ -344,7 +344,7 @@ If a preloader is running the value for the given prop is returned."
 The bound variables are \"singular\" and \"plural\".
 Argument DIR is the directory to which the search should be narrowed."
   `(let* ((singular (projectile-rails-current-resource-name))
-          (plural (pluralize-string singular))
+          (plural (inflection-pluralize-string singular))
           (abs-current-file (buffer-file-name (current-buffer)))
           (current-file (if abs-current-file
                             (file-relative-name abs-current-file
@@ -734,7 +734,7 @@ The bound variable is \"filename\"."
                           do (if (string-match re file-name)
                                  (return (match-string 1 file-name)))))))
     (and name
-         (singularize-string name))))
+         (inflection-singularize-string name))))
 
 (defun projectile-rails-list-entries (fun dir)
   "Call FUN on DIR being a relative directory within a rails project.
@@ -1042,7 +1042,7 @@ This only works when yas package is installed."
     (projectile-rails-goto-gem (thing-at-point 'filename)) t)
 
    ((string-match-p "^[a-z]" name)
-    (projectile-rails-find-constant (singularize-string name)) t)
+    (projectile-rails-find-constant (inflection-singularize-string name)) t)
 
    ((string-match-p "^\\(::\\)?[A-Z]" name)
     (projectile-rails-goto-constant-at-point) t)))


### PR DESCRIPTION
Hello! Updating this package recently, I noticed that it produced a fair amount of byte-compilation warnings. I decided to trim those back a bit.

Changes:
- Define a `defcustom` for `projectile-rails-custom-dbconsole-command`. The other "custom" commands had `defcustom`s, this one was just forgotten, I suppose.
- Replace the calls to the deprecated `pluralize-string` and `singularize-string` with their `inflection-` prefixed counterparts. This change was apparently made [three years ago](https://github.com/eschulte/jump.el/commit/9c7f918a2a04b40b9c7717ca21e3edbfcc9dd86d), so I don't think it will cause conflicts for people.

Love the package, and I'm happy to make any updates requested :smile: