### PR TITLE
Only expand rails snippets in rails projects

### DIFF
--- a/projectile-rails.el
+++ b/projectile-rails.el
@@ -1633,8 +1633,7 @@ If file does not exist and ASK in not nil it will ask user to proceed."
     (projectile-rails-set-assets-dirs)
     (projectile-rails-set-fixture-dirs)))
 
-(dolist (mode '(ruby-mode-hook enh-ruby-mode-hook))
-  (add-hook mode #'projectile-rails-expand-snippet-maybe))
+(add-hook 'projectile-rails-mode-hook #'projectile-rails-expand-snippet-maybe)
 
 ;;;###autoload
 (defun projectile-rails-on ()


### PR DESCRIPTION
While most of these do not apply, I'm finding the `require
"rails_helper"` in the spec skeleton a bit jarring when I'm creating
spec files in non-Rails Ruby projects. Granted, this snippet allows me
to specify which helper gets `require`'d, but I think I'd rather have
a hook that gave me good defaults for non-Rails projects when I'm not
in one, and this feels like the wrong place to introduce nuances like
that.