### PR TITLE
Unbind the mode's keymap

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,20 +50,36 @@ Probably you should read Projectile's [README](https://github.com/bbatsov/projec
 
 ### Customizing
 
+#### Keymap prefix
+Prior to version 0.20.0 the keymap prefix used to be setup. Following the [convention](https://www.gnu.org/software/emacs/manual/html_node/elisp/Key-Binding-Conventions.html) we have stopped doing this automatically.
+Now you need to attach the mode's map to the desired key yourself.
+For example to get the old key you can do:
+```el
+(define-key projectile-rails-mode-map (kbd "C-c r") 'projectile-rails-command-map)
+```
+
+#### Keywords
+
 The mode's buffers will have the Rails keywords highlighted. To turn it off:
 ```el
 (setq projectile-rails-add-keywords nil)
 ```
+
+#### Snippets
 
 If you have [yas-minor-mode or yas-global-mode](https://github.com/capitaomorte/yasnippet) enabled and you open a new file it will be filled with a skeleton class. To turn it off:
 ```el
 (setq projectile-rails-expand-snippet nil)
 ```
 
+#### ANSI Colors
+
 By default the buffer of the `projectile-rails-server-mode` is applying the ansi colors. If you find it slow you can disable it with:
 ```el
 (setq projectile-rails-server-mode-ansi-colors nil)
 ```
+
+#### External commands
 
 You can customize the way the `rails`, `spring` and `zeus` commands are invoked. For example if you want to use binstubs:
 
@@ -74,6 +90,9 @@ You can customize the way the `rails`, `spring` and `zeus` commands are invoked.
 ```
 
 ### Interactive commands
+
+The keymap is unbound by default. The following keybinding assume that you've bound it to `C-c r`. See [Keymap prefix](#keymap-prefix) section for details.
+-
 
 Command                                  | Keybinding                                 | Description
 -----------------------------------------|--------------------------------------------|-------------------------------------------------------
@@ -128,18 +147,6 @@ You might want to create your own keybinding for your favorite commands. For exa
 (define-key projectile-rails-mode-map (kbd "s-RET") 'projectile-rails-goto-file-at-point)
 (define-key projectile-rails-mode-map (kbd "C-c g")  projectile-rails-mode-goto-map)
 ```
-
-### Defining the keymap prefix
-
-Similar to Projectile Rails there is a variable exposed for defining the prefix for the mode's keymap.
-The name of the variable is `projectile-rails-keymap-prefix`.
-To attach the `projectile-rails` keymap to the `projectiles` keymap one can do:
-
-```el
-(setq projectile-rails-keymap-prefix (kbd "C-c p C-r"))
-```
-
-Please note though that in order for this code to work it has to be called before the mode is required/loaded.
 
 ### Discover
 

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -53,11 +53,18 @@ end")
     (when file-in-directory
       (f-delete file-in-directory t))))
 
-(require 'projectile-rails)
 (require 'espuds)
 (require 'ert)
 
 (Setup
+ ;; This needs to be set before the package is required.
+ (setq projectile-rails-keymap-prefix (kbd "C-c r"))
+
+ (require 'yasnippet)
+ (require 'bundler)
+ (require 'rspec-mode)
+ (require 'projectile-rails)
+
  (make-temp-file projectile-rails-test-app-path t)
  (loop for path in `("app/"
                      "app/assets/"
@@ -116,11 +123,6 @@ end")
                      ,(concat temporary-file-directory "spring/"))
        do (projectile-rails-test-touch-file path))
 
- (require 'yasnippet)
- (require 'bundler)
- (require 'rspec-mode)
- (require 'projectile-rails)
-
  (setq kill-buffer-query-functions nil
        projectile-completion-system 'default
        projectile-indexing-method 'native
@@ -128,7 +130,6 @@ end")
  (yas-global-mode)
 
  (cd projectile-rails-test-app-path))
-
 
 (Before
  (loop for file in (list projectile-rails-test-spring-pid-file

--- a/projectile-rails.el
+++ b/projectile-rails.el
@@ -211,10 +211,12 @@
   :group 'projectile-rails
   :type 'boolean)
 
-(defcustom projectile-rails-keymap-prefix (kbd "C-c r")
+(defcustom projectile-rails-keymap-prefix nil
   "Keymap prefix for `projectile-rails-mode'."
   :group 'projectile-rails
   :type 'string)
+
+(make-obsolete-variable 'projectile-keymap-prefix "Use (define-key projectile-rails-mode-map (kbd ...) 'projectile-rails-command-map) instead." "0.20.0")
 
 (defcustom projectile-rails-server-mode-ansi-colors t
   "If not nil `projectile-rails-server-mode' will apply the ansi colors in its buffer."
@@ -1562,7 +1564,8 @@ If file does not exist and ASK in not nil it will ask user to proceed."
 
 (defvar projectile-rails-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map projectile-rails-keymap-prefix 'projectile-rails-command-map)
+    (when projectile-rails-keymap-prefix
+      (define-key map projectile-rails-keymap-prefix 'projectile-rails-command-map))
     map)
   "Keymap for `projectile-rails-mode'.")
 


### PR DESCRIPTION
The Emacs convention is to have the key `C-c` unbound.
This is a breaking change that projectile was also going through.

Related to #138