### PR TITLE
Fix projectile-rails-dbconsole command

### DIFF
--- a/projectile-rails.el
+++ b/projectile-rails.el
@@ -911,8 +911,8 @@ The buffer for interacting with SQL client is created via `sql-product-interacti
      (sql-set-product-feature product :sqli-login '())
      (sql-set-product-feature product :sqli-options '())
      (sql-set-product-feature product :sqli-program (car commands))
-     (sql-set-product-feature product :sqli-comint-func (lambda (_ __)
-                                                          (sql-comint product (cdr commands))))
+     (sql-set-product-feature product :sqli-comint-func (lambda (_ __ &optional buf-name)
+                                                          (sql-comint product (cdr commands) buf-name)))
 
      (sql-product-interactive product)
 


### PR DESCRIPTION
`projectile-rails-dbconsole` command did not work properly because the number of parameters for `sql-comint-func` has changed.
This patch adds a new optional parameter (buf-name) to `sql-comit-func` generated in `projectile-rails-dbconsole` to fix it.