### PR TITLE
Use auto-insert-mode to insert and expand the snippet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+master (unreleased)
+
+## master (unreleased)
+
+* Use `auto-insert-mode` to insert snippets. User needs to have the mode enabled in order for the feature to work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # Changelog
 
-master (unreleased)
-
 ## master (unreleased)
 
 * Use `auto-insert-mode` to insert snippets. User needs to have the mode enabled in order for the feature to work.

--- a/README.md
+++ b/README.md
@@ -67,10 +67,12 @@ The mode's buffers will have the Rails keywords highlighted. To turn it off:
 
 #### Snippets
 
-If you have [yas-minor-mode or yas-global-mode](https://github.com/capitaomorte/yasnippet) enabled and you open a new file it will be filled with a skeleton class. To turn it off:
+If you have [yas-minor-mode or yas-global-mode](https://github.com/capitaomorte/yasnippet) and `auto-insert-mode` enabled and you open a new file it will be filled with a skeleton class. To turn it off:
 ```el
 (setq projectile-rails-expand-snippet nil)
 ```
+
+Note: this variable controls whether `auto-insert-mode` is configured, that is if you set this variable to nil after you opened any rails file the snippets will still be inserted. In order to disable this feature in such scenarios just disable `auto-insert-mode` instead.
 
 #### ANSI Colors
 

--- a/features/expanding-snippets-in-new-buffers.feature
+++ b/features/expanding-snippets-in-new-buffers.feature
@@ -5,38 +5,36 @@ Feature: Filling new buffer with class definition
 
 Background:
   Given I turn on snippet expansion
+  And I turn on auto-insert-mode
 
-  @pending
 Scenario: Opening new model
-  When I open the app file "app/models/foo.rb"
-  And I turn on projectile-rails-mode
+  When I turn on projectile-rails-mode
+  And I open the app file "app/models/new_model.rb"
   Then disregarding whitespaces I should see:
   """
   # frozen_string_literal: true
 
-  class Foo < ActiveRecord::Base
+  class NewModel < ActiveRecord::Base
 
   end
   """
 
-  @pending
 Scenario: Opening new model when ApplicationRecord exists
   Given file "app/models/application_record.rb" exists
-  When I open the app file "app/models/foo.rb"
-  And I turn on projectile-rails-mode
+  When I turn on projectile-rails-mode
+  And I open the app file "app/models/bar.rb"
   Then disregarding whitespaces I should see:
   """
   # frozen_string_literal: true
 
-  class Foo < ApplicationRecord
+  class Bar < ApplicationRecord
 
   end
   """
 
-  @pending
 Scenario: Opening new controller
-  When I open the app file "app/controllers/foos_controller.rb"
-  And I turn on projectile-rails-mode
+  When I turn on projectile-rails-mode
+  And I open the app file "app/controllers/foos_controller.rb"
   Then disregarding whitespaces I should see:
   """
   # frozen_string_literal: true
@@ -46,11 +44,10 @@ Scenario: Opening new controller
   end
   """
 
-  @pending
 Scenario: Opening a new namespaced controller
   Given directory "app/controllers/admin/" exists
-  When I open the app file "app/controllers/admin/foos_controller.rb"
   And I turn on projectile-rails-mode
+  And I open the app file "app/controllers/admin/foos_controller.rb"
   Then disregarding whitespaces I should see:
   """
   # frozen_string_literal: true
@@ -60,10 +57,9 @@ Scenario: Opening a new namespaced controller
   end
   """
 
-  @pending
 Scenario: Opening a new job
-  When I open the app file "app/jobs/foo_job.rb"
-  And I turn on projectile-rails-mode
+  When I turn on projectile-rails-mode
+  And I open the app file "app/jobs/foo_job.rb"
   Then disregarding whitespaces I should see:
   """
   # frozen_string_literal: true
@@ -73,10 +69,9 @@ Scenario: Opening a new job
   end
   """
 
-  @pending
 Scenario: Opening a new lib
-  When I open the app file "lib/fooing.rb"
-  And I turn on projectile-rails-mode
+  When I turn on projectile-rails-mode
+  And I open the app file "lib/fooing.rb"
   Then disregarding whitespaces I should see:
   """
   # frozen_string_literal: true
@@ -86,26 +81,22 @@ Scenario: Opening a new lib
   end
   """
 
-  @pending
 Scenario: Opening a new file under the app directory
-  When I open the app file "app/jobs/admin/foo_job.rb"
-  And I turn on projectile-rails-mode
+  When I turn on projectile-rails-mode
+  And I open the app file "app/jobs/admin/foo_job.rb"
   Then disregarding whitespaces I should see:
   """
   # frozen_string_literal: true
 
-  module Admin
-    class FooJob
+  class Admin::FooJob < ApplicationJob
 
-    end
   end
   """
 
-  @pending
 Scenario: Opening a new namespaced lib
-  Given directory "lib/admin/" exists
+  When I turn on projectile-rails-mode
+  And directory "lib/admin/" exists
   When I open the app file "lib/admin/fooing.rb"
-  And I turn on projectile-rails-mode
   Then disregarding whitespaces I should see:
   """
   # frozen_string_literal: true
@@ -117,10 +108,9 @@ Scenario: Opening a new namespaced lib
   end
   """
 
-  @pending
 Scenario: Opening a new spec
-  When I open the app file "spec/models/bar_spec.rb"
-  And I turn on projectile-rails-mode
+  When I turn on projectile-rails-mode
+  And I open the app file "spec/models/bar_spec.rb"
   Then disregarding whitespaces I should see:
   """
   # frozen_string_literal: true
@@ -132,10 +122,9 @@ Scenario: Opening a new spec
   end
   """
 
-  @pending
 Scenario: Opening a new concern
-  When I open the app file "app/models/concerns/foo.rb"
-  And I turn on projectile-rails-mode
+  When I turn on projectile-rails-mode
+  And I open the app file "app/models/concerns/foo.rb"
   Then disregarding whitespaces I should see:
   """
   # frozen_string_literal: true
@@ -146,10 +135,9 @@ Scenario: Opening a new concern
   end
   """
 
-  @pending
 Scenario: Opening a new helper
-  When I open the app file "app/helpers/foo_helper.rb"
-  And I turn on projectile-rails-mode
+  When I turn on projectile-rails-mode
+  And I open the app file "app/helpers/foo_helper.rb"
   Then disregarding whitespaces I should see:
   """
   # frozen_string_literal: true
@@ -159,26 +147,10 @@ Scenario: Opening a new helper
   end
   """
 
-  @pending
-Scenario: Opening a new spec and the buffer is not empty
-  When I open the app file "spec/models/bar_spec.rb"
-  And I insert:
-  """
-  Emacs!
-  """
-  And I turn on projectile-rails-mode
-  Then I should not see:
-  """
-  # frozen_string_literal: true
-
-  require "spec_helper"
-  """
-
-  @pending
 Scenario: Disabling the feature
-  Given I turn off snippet expansion
+  When I turn on projectile-rails-mode
+  And I turn off snippet expansion
   When I open the app file "spec/models/bar_spec.rb"
-  And I turn on projectile-rails-mode
   Then I should not see:
   """
   # frozen_string_literal: true

--- a/features/font-locking.feature
+++ b/features/font-locking.feature
@@ -30,8 +30,8 @@ Scenario: Font locking controllers keywords
   And I should see "alias_attribute" font locked
 
 Scenario: Font locking migrations keywords
-  Given file "db/migrate/20131118160600_create_users.rb" exists
-  And I open the app file "db/migrate/20131118160600_create_users.rb"
+  Given file "db/migrate/20131118160601_create_users.rb" exists
+  And I open the app file "db/migrate/20131118160601_create_users.rb"
   And I insert:
   """
   create_table
@@ -43,8 +43,8 @@ Scenario: Font locking migrations keywords
   And I should see "alias_attribute" font locked
 
 Scenario: Disabling the feature
-  Given file "db/migrate/20131118160600_create_users.rb" exists
-  And I open the app file "db/migrate/20131118160600_create_users.rb"
+  Given file "db/migrate/20131118160600_create_another_users.rb" exists
+  And I open the app file "db/migrate/20131118160600_create_another_users.rb"
   And I insert:
   """
   alias_attribute

--- a/features/step-definitions/projectile-rails-steps.el
+++ b/features/step-definitions/projectile-rails-steps.el
@@ -13,6 +13,11 @@
       (lambda ()
         (projectile-rails-off)))
 
+(When "^I turn on auto-insert-mode$"
+      (lambda ()
+        (auto-insert-mode)
+        (setq auto-insert-query nil)))
+
 (When "^I run command \"\\(.+\\)\" \\(?:selecting\\|inputting\\) \"\\(.+\\)\"$"
       (lambda (command argument)
         (When "I start an action chain")

--- a/features/support/env.el
+++ b/features/support/env.el
@@ -141,6 +141,7 @@ end")
 
 (After
  (yas-exit-all-snippets)
+ (auto-insert-mode -1)
  (--each (buffer-list)
    (with-current-buffer it
      (when projectile-rails-mode


### PR DESCRIPTION
It's working better than the current snippet expansion plus
it is more in the Emacs spirit (you can enable/disable auto-insert mode control
the feature).