### PR TITLE
Fix "wrong type argument char-or-string-p" when no snippet is available

### DIFF
--- a/projectile-rails.el
+++ b/projectile-rails.el
@@ -946,7 +946,9 @@ So it safe to call it many times like in a minor mode hook."
       (define-auto-insert
         current-project-cond
        [
-        (lambda () (insert (projectile-rails-corresponding-snippet)))
+        (lambda ()
+          (let ((snippet (projectile-rails-corresponding-snippet)))
+            (if snippet (insert snippet))))
         projectile-rails-expand-yas-buffer
         ]
        ))))

--- a/projectile-rails.el
+++ b/projectile-rails.el
@@ -948,7 +948,8 @@ So it safe to call it many times like in a minor mode hook."
        [
         (lambda ()
           (let ((snippet (projectile-rails-corresponding-snippet)))
-            (if snippet (insert snippet))))
+            (when snippet
+              (insert snippet))))
         projectile-rails-expand-yas-buffer
         ]
        ))))


### PR DESCRIPTION
Before this, whenever I created a file for which there wasn't a suitable snippet, I'd get "wrong type argument char-or-string-p" on calling `(insert nil)`.

I'm surprised that other people don't seem to have this error crop up all the time, so let me know if you think there's something weird going on with my setup...