### PR TITLE
Remove file.rb of projectile-rails--ruby-mode-indent-tabs-p

### DIFF
--- a/projectile-rails.el
+++ b/projectile-rails.el
@@ -975,7 +975,6 @@ In order to expand snippet in newly created buffers variable
 
 (defun projectile-rails--ruby-mode-indent-tabs-p ()
   (with-temp-buffer
-    (set-visited-file-name "file.rb")
     (set-auto-mode)
     indent-tabs-mode))
 


### PR DESCRIPTION
At least on doom-emacs, when you try to create a file and this function is called, it creates an annoying file.rb on the project and keep asking to save or kill.  

Removing this, fixes the problem