### PR TITLE
Pass --noreadline argument to rails console

### DIFF
--- a/projectile-rails.el
+++ b/projectile-rails.el
@@ -865,7 +865,7 @@ but consider `projectile-rails-root'."
                                  :vanilla (concat projectile-rails-vanilla-command " console"))))
 
      (when (inf-ruby--irb-needs-nomultiline-p)
-       (setq rails-console-command (concat rails-console-command " -- --nomultiline")))
+       (setq rails-console-command (concat rails-console-command " -- --nomultiline --noreadline")))
 
      (with-demoted-errors
          (inf-ruby-console-run


### PR DESCRIPTION
In Ruby 3.3.0, the Rails console breaks, duplicating text and printing unknown code. Including the `--noreadline` argument to IRB fix this issue.

3.2.2:
![image](https://github.com/asok/projectile-rails/assets/58234608/8d012ede-b388-4043-8363-70d0abcf83c6)

3.3.0:
![image](https://github.com/asok/projectile-rails/assets/58234608/cbced08b-864d-4be7-b91e-92fead04d69e)

The `inf-ruby` package [already does this](https://github.com/nonsequitur/inf-ruby/blob/8116b3b8336819a9838dd73e6926b5ba6d57c05e/inf-ruby.el#L1127), and it seems to work OK