### PR TITLE
Improve handling of filenames with multiple dots in path extraction

### DIFF
--- a/projectile-rails.el
+++ b/projectile-rails.el
@@ -1373,7 +1373,7 @@ If called interactively will ask user for the PARTIAL-NAME."
         (snippet (cdr (assoc (f-ext partial-name) projectile-rails-extracted-region-snippet)))
         (path (replace-regexp-in-string "\/_" "/" (s-chop-prefix
                                                    (projectile-rails-expand-root "app/views/")
-                                                   (cl-first (s-slice-at "\\." partial-name))))))
+                                                   (replace-regexp-in-string "\.[^.]+?\.\[^.]+?$" "" partial-name)))))
     (kill-region (region-beginning) (region-end))
     (deactivate-mark)
     (when (projectile-rails--view-p (buffer-file-name))


### PR DESCRIPTION
I would like to express my gratitude for the work you've done on the projectile-rails library, which is a valuable tool for the Rails community.

I'm submitting this pull request to address an issue with the path extraction of filenames containing multiple dots. The current implementation of the `projectile-rails-extract-region` function does not effectively handle filenames with multiple dots, leading to incorrect file path extraction.

I've updated the function to use a regular expression with `replace-regexp-in-string`, replacing the `s-slice-at` method. This change ensures more accurate handling of filenames with multiple periods, improving the function's robustness.

I've been using this change in my actual work environment for some time without any issues, although it hasn't been extensively tested. I believe this update will be beneficial to other users as well.

Thank you for considering this pull request. 
